### PR TITLE
Update Madex 1.3.4.0

### DIFF
--- a/Adapters/Madex/CHANGELOG.md
+++ b/Adapters/Madex/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Madex Android Mediation Adapter Changelog
 `com.cleveradssolutions:madex:`
 
+### 1.3.4.0
+- Certified with Madex - 1.3.4
+- Downgrade the dependencies to `androidx.appcompat:appcompat:1.0.0` and `com.google.android.material:material:1.3.0`.
+
 ### 1.3.3.0
 - Certified with Madex - 1.3.3
 


### PR DESCRIPTION
- Certified with Madex - 1.3.4
- Downgrade the dependencies to `androidx.appcompat:appcompat:1.0.0` and `com.google.android.material:material:1.3.0`.