### PR TITLE
Update CAS Gradle plugin version 3.9.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.cas_version = '3.9.3'
+    ext.cas_version = '3.9.3.1'
 
     ext.kotlin_version = '1.8.22'
 


### PR DESCRIPTION
With fixes for build error: `invocation of 'Task.project' at execution time is unsupported`.