### PR TITLE
Update CAS Gradle Plugin 3.9.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.cas_version = '3.9.7'
+    ext.cas_version = '3.9.7.1'
 
     ext.kotlin_version = '1.8.22'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ dependencyResolutionManagement {
         mavenCentral()
         maven {
             name = "CASBetaRepo"
-            url = "https://repsy.io/mvn/cleveradssolutions/beta"
+            url = "https://repo.repsy.io/mvn/cleveradssolutions/beta"
             content { it.includeGroup("com.cleveradssolutions") }
         }
         maven {


### PR DESCRIPTION
Published the CAS Gradle plugin version 3.9.7.1 with fixes for `productFlavors` redefine the `applicationId` property.