### PR TITLE
Update CAS Gradle Plugin 3.9.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.cas_version = '3.9.8'
+    ext.cas_version = '3.9.8.1'
 
     ext.kotlin_version = '1.8.22'
 


### PR DESCRIPTION
Published the CAS Gradle plugin version 3.9.8.1 with fix for build error:
```
Cannot change dependencies of dependency configuration 'implementation' after it has been included in dependency resolution
```

Also error message `no build variants found for the module` was replaced with a more informative one.

Fixes #12