### PR TITLE
Update CAS Gradle Plugin 3.9.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.cas_version = '3.9.10'
+    ext.cas_version = '3.9.10.1'
 
     ext.kotlin_version = '1.8.22'
 


### PR DESCRIPTION
Published the CAS Gradle plugin version 3.9.10.1. 
- Added support for CAS ID variants in library module integrations.
```groovy
cas {
   casId = "Main App CAS Id"
   addCasIdVariant("Variant name", "Main App CAS Id + Variant")
}
```
You can now define CAS IDs for specific project configurations, such as build variants or product flavors. The CAS ID will be overridden for any configuration whose name contains the specified variant name.

> [!WARNING] 
> These settings will be ignored when integrating into Application modules, as the applicationId (with all modifications for Build Variant and Product Flavor) will always be used as the CAS ID for app-level modules. 